### PR TITLE
use existing recognizer if present

### DIFF
--- a/src/index.android.js
+++ b/src/index.android.js
@@ -16,40 +16,41 @@ export class SpeechRecognition {
 
   start() {
     if (this._recognizer) {
-      this._recognizer.destroy();
-      this._recognizer = null;
+      this._recognizer.startListening(RecognizerIntent.ACTION_RECOGNIZE_SPEECH, {});
     }
-    SpeechRecognizer.createSpeechRecognizer().then(recognizer => {
-      this._recognizer = recognizer;
-      const listeners = {};
-      if (this.onspeechstart) {
-        listeners.onBeginningOfSpeech = () => this.onspeechstart();
-      }
-      if (this.onspeechend) {
-        listeners.onEndOfSpeech = () => this.onspeechend();
-      }
-      if (this.onerror) {
-        listeners.onError = event => this.onerror({
-          error: "Failed with error code: " + event.error
-        });
-      }
-      listeners.onResults = event => {
-        const recognition = event.results[SpeechRecognizer.RESULTS_RECOGNITION];
-        const bestRecognition = recognition[0];
-        const speechRecognitionEvent = {
-          resultIndex: 0,
-          results: [[{
-            transcript: bestRecognition
-          }]],
+    else {
+      SpeechRecognizer.createSpeechRecognizer().then(recognizer => {
+        this._recognizer = recognizer;
+        const listeners = {};
+        if (this.onspeechstart) {
+          listeners.onBeginningOfSpeech = () => this.onspeechstart();
         }
-        speechRecognitionEvent.results[0].isFinal = true;
-        if (this.onresult) {
-          this.onresult(speechRecognitionEvent);
+        if (this.onspeechend) {
+          listeners.onEndOfSpeech = () => this.onspeechend();
         }
-      }
-      recognizer.setRecognitionListener(listeners);
-      recognizer.startListening(RecognizerIntent.ACTION_RECOGNIZE_SPEECH, {});
-    });
+        if (this.onerror) {
+          listeners.onError = event => this.onerror({
+            error: "Failed with error code: " + event.error
+          });
+        }
+        listeners.onResults = event => {
+          const recognition = event.results[SpeechRecognizer.RESULTS_RECOGNITION];
+          const bestRecognition = recognition[0];
+          const speechRecognitionEvent = {
+            resultIndex: 0,
+            results: [[{
+              transcript: bestRecognition
+            }]],
+          }
+          speechRecognitionEvent.results[0].isFinal = true;
+          if (this.onresult) {
+            this.onresult(speechRecognitionEvent);
+          }
+        }
+        recognizer.setRecognitionListener(listeners);
+        recognizer.startListening(RecognizerIntent.ACTION_RECOGNIZE_SPEECH, {});
+      });
+    }
   }
 
   stop() {


### PR DESCRIPTION
In using this, I found that despite the call to the SpeechRecognizer instance's `.destroy()` function at the beginning of `start`, listeners were hanging around and calling back every time an utterance was recognized. 

So, instead of attempting (and failing) to remove the previous instance of the `SpeechRecognizer`, if a previous recognizer instance is found, this calls that instance's `startListening` method.